### PR TITLE
Added a github action to the existing pipeline to commit and push Readme files to the journey.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -6,7 +6,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
-
+    
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -14,21 +14,21 @@ jobs:
   # generate README.md for journey files
   readme:
     runs-on: ubuntu-latest
-
+    
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
+        
       - name: install node
         uses: actions/setup-node@v3
         with:
           node-version: 14
-
+          
       - name: Install frodo-cli
         run: |
           npm i -g @rockcarver/frodo-cli
           frodo -v
-
+          
       - name: Generate README.md files
         run: |
           find . -name "*.journey.json" -exec sh -c 'frodo journey describe -f "$0" --markdown --output-file "${0%/*}/README.md"' {} \;
@@ -37,13 +37,6 @@ jobs:
         run: |
           git status
         
-      - name: Commit updated files
-        run: |
-          echo ${{ github.head_ref }}
-          git config user.name "vscheuber"
-          git config user.email "vscheuber@gmail.com"
-          git add */**/README.md
-          git commit --message "Created or updated README.md files"
-          echo "commit successful"
-          git push origin ${{ github.head_ref }}
-          
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: update readme files


### PR DESCRIPTION
Modified the existing pipeline to commit and add files using this [GitHub Action](https://github.com/stefanzweifel/git-auto-commit-action).

This GItHub Action used GitHub bot as a co-author to the original committer.

This pipeline gets triggered when a new PR containing a journey is created for the main branch. 

The first part of the pipeline, written Volker Scheuber, add a Readme.md file to a journey using Frodo cli capapabilites.
The last part of the pipeline utilizes commit & add GitHub Action replaces the hardcoded part of commit command and replaces it with GitHub bot. The GitHub Bot as a co-author, adds the above created Readme file, commits and pushes to the PR branch.

This modified pipeline makes contributing to the Journey Library simpler.

Auto-commit workflow in action:

https://github.com/ForgeRock/forgerock-journeys-library/pull/8#issuecomment-1487446876

